### PR TITLE
SampleApp_addPreventIOS9ATS

### DIFF
--- a/Samples/Display/AMoAdSample/AMoAdSample/Info.plist
+++ b/Samples/Display/AMoAdSample/AMoAdSample/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>

--- a/Samples/DisplayInterstitial/AMoAdInterstitialAdSample/AMoAdInterstitialAdSample/Info.plist
+++ b/Samples/DisplayInterstitial/AMoAdInterstitialAdSample/AMoAdInterstitialAdSample/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+<key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>

--- a/Samples/Native/AMoAdNativeAppIconText/AMoAdNativeAppIconText/Info.plist
+++ b/Samples/Native/AMoAdNativeAppIconText/AMoAdNativeAppIconText/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>

--- a/Samples/Native/AMoAdNativeAppIconTextLink/AMoAdNativeAppIconTextLink/Info.plist
+++ b/Samples/Native/AMoAdNativeAppIconTextLink/AMoAdNativeAppIconTextLink/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>

--- a/Samples/Native/AMoAdNativeAppImageText/AMoAdNativeAppImageText/Info.plist
+++ b/Samples/Native/AMoAdNativeAppImageText/AMoAdNativeAppImageText/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>

--- a/Samples/Native/AMoAdNativeAppImageTextCoder/AMoAdNativeAppImageText/Info.plist
+++ b/Samples/Native/AMoAdNativeAppImageTextCoder/AMoAdNativeAppImageText/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>

--- a/Samples/Native/AMoAdNativeAppText/AMoAdNativeAppText/Info.plist
+++ b/Samples/Native/AMoAdNativeAppText/AMoAdNativeAppText/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/Samples/Native/AMoAdNativeCollectionViewIconText/AMoAdNativeCollectionViewIconText/Info.plist
+++ b/Samples/Native/AMoAdNativeCollectionViewIconText/AMoAdNativeCollectionViewIconText/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>

--- a/Samples/Native/AMoAdNativeCollectionViewImageText/AMoAdNativeCollectionViewImageText/Info.plist
+++ b/Samples/Native/AMoAdNativeCollectionViewImageText/AMoAdNativeCollectionViewImageText/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>

--- a/Samples/Native/AMoAdNativeCollectionViewText/AMoAdNativeCollectionViewText/Info.plist
+++ b/Samples/Native/AMoAdNativeCollectionViewText/AMoAdNativeCollectionViewText/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>

--- a/Samples/Native/AMoAdNativeListViewIconText/AMoAdNativeListViewIconText/Info.plist
+++ b/Samples/Native/AMoAdNativeListViewIconText/AMoAdNativeListViewIconText/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>

--- a/Samples/Native/AMoAdNativeListViewImageText/AMoAdNativeListViewImageText/Info.plist
+++ b/Samples/Native/AMoAdNativeListViewImageText/AMoAdNativeListViewImageText/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>

--- a/Samples/Native/AMoAdNativeListViewText/AMoAdNativeListViewText/Info.plist
+++ b/Samples/Native/AMoAdNativeListViewText/AMoAdNativeListViewText/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>

--- a/Samples/NativePreRoll/AMoAdNativePreRoll/AMoAdNativePreRoll/Info.plist
+++ b/Samples/NativePreRoll/AMoAdNativePreRoll/AMoAdNativePreRoll/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>


### PR DESCRIPTION
サンプルのアプリに対してiOS9から導入されたATSが適用されないように設定を追加しました。